### PR TITLE
Link directly to /schedule/day-1 to skip the redirect

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -1,8 +1,12 @@
 ---
 const FAQ_LINK = 'https://www.sunny-tech.io/faq'
 
-const navigation = [
-    { label: 'Programme', route: '/schedule' },
+type NavItem = { label: string; route: string; activeMatch?: string }
+
+const navigation: NavItem[] = [
+    // Link directly to day-1 to skip the /schedule → /schedule/day-1 redirect,
+    // but highlight the entry for any /schedule/* page.
+    { label: 'Programme', route: '/schedule/day-1', activeMatch: '/schedule' },
     { label: 'Speakers', route: '/speakers' },
     { label: 'Équipe', route: '/team' },
     // { label: 'Jobs', route: '/jobs' },
@@ -14,12 +18,13 @@ const navigation = [
 
 const routeName = Astro.url.pathname
 
-const isActiveRoute = (route: string) => {
-    if (route === '/') {
-        return route === routeName
+const isActiveRoute = (nav: NavItem) => {
+    const match = nav.activeMatch ?? nav.route
+    if (match === '/') {
+        return match === routeName
     }
 
-    return routeName.startsWith(route)
+    return routeName.startsWith(match)
 }
 ---
 
@@ -33,7 +38,7 @@ const isActiveRoute = (route: string) => {
         <nav class="nav-items">
             {
                 navigation.map((nav) => (
-                    <a href={nav.route} class:list={['nav-item', { active: isActiveRoute(nav.route) }]}>
+                    <a href={nav.route} class:list={['nav-item', { active: isActiveRoute(nav) }]}>
                         {nav.label}
                     </a>
                 ))
@@ -51,7 +56,7 @@ const isActiveRoute = (route: string) => {
                 (
                     <nav class="nav-items">
                         {navigation.map((nav) => (
-                            <a href={nav.route} class:list={['nav-item', { active: isActiveRoute(nav.route) }]}>
+                            <a href={nav.route} class:list={['nav-item', { active: isActiveRoute(nav) }]}>
                                 {nav.label}
                             </a>
                         ))}

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -15,7 +15,7 @@ import Cluster from '../ui-elements/Cluster.astro'
         <h2 class="fs1 fw-regular">#SeaTechAndSun ☀️️️</h2>
 
         <Cluster>
-            <ButtonLink href="/schedule">Voir le programme</ButtonLink>
+            <ButtonLink href="/schedule/day-1">Voir le programme</ButtonLink>
             <ButtonLink href="https://www.billetweb.fr/sunny-tech-2026" target="_blank" external>
                 Accéder à la billetterie
             </ButtonLink>


### PR DESCRIPTION
## Summary
- Every internal link to the schedule pointed at \`/schedule\`, which \`astro.config.mjs\` then redirects to \`/schedule/day-1\`. That extra hop shows up in the network waterfall and logs \`/schedule\` in analytics for no real reason.
- Point the two internal callers directly at \`/schedule/day-1\`.

## Changes
- \`src/components/Menu.astro\` — the Programme nav entry now links to \`/schedule/day-1\`. Added an \`activeMatch\` of \`/schedule\` so any \`/schedule/day-*\` page still highlights the entry.
- \`src/components/home/Hero.astro\` — the "Voir le programme" CTA goes straight to \`/schedule/day-1\`.

The redirect rule itself stays in \`astro.config.mjs\` as a safety net for external inbound links (shares, old bookmarks) that still reference \`/schedule\`.

## Test plan
- [ ] Click "Programme" in the header from the home page: browser loads \`/schedule/day-1\` with no intermediate 301/302.
- [ ] Click "Voir le programme" hero button: same.
- [ ] Visit \`/schedule/day-2\`, \`/schedule/day-favorite\`: "Programme" stays highlighted in the nav.
- [ ] External \`/schedule\` URLs still redirect to \`/schedule/day-1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)