### PR TITLE
View transition on speaker avatar

### DIFF
--- a/src/components/schedule/DaySchedule.astro
+++ b/src/components/schedule/DaySchedule.astro
@@ -73,6 +73,7 @@ const gridTemplateColumns = `${GRID_CONFIG.TIME_COLUMN_WIDTH} repeat(${tracks.le
                             category={session.category}
                             speakers={session.speakers}
                             language={session.language || 'fr'}
+                            viewTransitionPrefix={`session-${session.id}`}
                         />
                     </div>
                 )

--- a/src/components/schedule/SessionItem.astro
+++ b/src/components/schedule/SessionItem.astro
@@ -17,6 +17,7 @@ interface Props {
     alwaysShowExtraInfo?: boolean
     hideBookmark?: boolean
     language?: string
+    viewTransitionPrefix?: string
 }
 
 const {
@@ -30,6 +31,7 @@ const {
     language,
     alwaysShowExtraInfo = false,
     hideBookmark = false,
+    viewTransitionPrefix = '',
 } = Astro.props
 ---
 
@@ -69,6 +71,7 @@ const {
                                         photoUrl={speaker.photoUrl}
                                         name={speaker.name}
                                         company={speaker.company}
+                                        viewTransitionPrefix={viewTransitionPrefix}
                                     />
                                 ))}
                             </Cluster>

--- a/src/components/schedule/SessionItem.astro
+++ b/src/components/schedule/SessionItem.astro
@@ -31,7 +31,7 @@ const {
     language,
     alwaysShowExtraInfo = false,
     hideBookmark = false,
-    viewTransitionPrefix = '',
+    viewTransitionPrefix,
 } = Astro.props
 ---
 

--- a/src/components/schedule/Speaker.astro
+++ b/src/components/schedule/Speaker.astro
@@ -2,7 +2,7 @@
 import GenericIcon from '../icons/GenericIcon.astro'
 import Cluster from '../ui-elements/Cluster.astro'
 
-const { id, photoUrl, name, company, size, socials } = Astro.props
+const { id, photoUrl, name, company, size, socials, viewTransitionPrefix } = Astro.props
 ---
 
 <div class="speaker" data-size={size}>
@@ -13,7 +13,7 @@ const { id, photoUrl, name, company, size, socials } = Astro.props
                     alt=""
                     class="speaker-photo"
                     src={photoUrl}
-                    transition:name={`speaker-photo-${id}`}
+                    transition:name={`${viewTransitionPrefix}-speaker-photo-${id}`}
                     transition:animate="slide"
                 />
             )

--- a/src/components/schedule/Speaker.astro
+++ b/src/components/schedule/Speaker.astro
@@ -7,7 +7,17 @@ const { id, photoUrl, name, company, size, socials } = Astro.props
 
 <div class="speaker" data-size={size}>
     <Cluster space="var(--s-3) var(--s-2)" align="flex-start" nowrap>
-        {photoUrl && <img alt="" class="speaker-photo" src={photoUrl} />}
+        {
+            photoUrl && (
+                <img
+                    alt=""
+                    class="speaker-photo"
+                    src={photoUrl}
+                    transition:name={`speaker-photo-${id}`}
+                    transition:animate="slide"
+                />
+            )
+        }
         {!photoUrl && <span class="speaker-photo-fallback">{name.charAt(0).toUpperCase()}</span>}
 
         <div class="speaker-info">

--- a/src/components/schedule/Speaker.astro
+++ b/src/components/schedule/Speaker.astro
@@ -3,20 +3,27 @@ import GenericIcon from '../icons/GenericIcon.astro'
 import Cluster from '../ui-elements/Cluster.astro'
 
 const { id, photoUrl, name, company, size, socials, viewTransitionPrefix } = Astro.props
+// Only participate in the view-transition pair when a caller asks for it.
+// Without a prefix the generated name would be `undefined-speaker-photo-<id>`
+// and collide with every other unkeyed render of this component on the page.
+const transitionName = viewTransitionPrefix ? `${viewTransitionPrefix}-speaker-photo-${id}` : undefined
 ---
 
 <div class="speaker" data-size={size}>
     <Cluster space="var(--s-3) var(--s-2)" align="flex-start" nowrap>
         {
-            photoUrl && (
-                <img
-                    alt=""
-                    class="speaker-photo"
-                    src={photoUrl}
-                    transition:name={`${viewTransitionPrefix}-speaker-photo-${id}`}
-                    transition:animate="slide"
-                />
-            )
+            photoUrl &&
+                (transitionName ? (
+                    <img
+                        alt=""
+                        class="speaker-photo"
+                        src={photoUrl}
+                        transition:name={transitionName}
+                        transition:animate="slide"
+                    />
+                ) : (
+                    <img alt="" class="speaker-photo" src={photoUrl} />
+                ))
         }
         {!photoUrl && <span class="speaker-photo-fallback">{name.charAt(0).toUpperCase()}</span>}
 

--- a/src/pages/sessions/[...slug].astro
+++ b/src/pages/sessions/[...slug].astro
@@ -132,6 +132,7 @@ const openFeedbackLink = showInFeedback
                             photoUrl={speaker.photoUrl}
                             name={speaker.name}
                             company={speaker.company}
+                            viewTransitionPrefix={`session-${id}`}
                         />
                     ))
                 }

--- a/src/pages/speakers/[slug].astro
+++ b/src/pages/speakers/[slug].astro
@@ -108,7 +108,6 @@ const ogImage = `${import.meta.env.SITE}/og/speakers/${ogSlug}.png`
                             speakers={[Astro.props]}
                             alwaysShowExtraInfo
                             hideBookmark
-                            viewTransitionPrefix={`sessionItemIgnored`}
                         />
                     ))}
                 </div>

--- a/src/pages/speakers/[slug].astro
+++ b/src/pages/speakers/[slug].astro
@@ -43,7 +43,7 @@ export const getStaticPaths = async () => {
         }
     })
 }
-const { name, company, bio, jobTitle, socials, photoUrl, sessions, ogSlug } = Astro.props
+const { name, company, bio, jobTitle, socials, photoUrl, sessions, ogSlug, id } = Astro.props
 const ogImage = `${import.meta.env.SITE}/og/speakers/${ogSlug}.png`
 ---
 
@@ -55,6 +55,8 @@ const ogImage = `${import.meta.env.SITE}/og/speakers/${ogSlug}.png`
                 class="speaker-photo"
                 style={{ width: '48px', height: '48px', borderRadius: '50%', display: 'inline-block' }}
                 slot="pre-title"
+                transition:name={`session-${(sessions || []).length === 1 ? sessions[0].id : ''}-speaker-photo-${id}`}
+                transition:animate="slide"
             />
         )
     }
@@ -106,6 +108,7 @@ const ogImage = `${import.meta.env.SITE}/og/speakers/${ogSlug}.png`
                             speakers={[Astro.props]}
                             alwaysShowExtraInfo
                             hideBookmark
+                            viewTransitionPrefix={`sessionItemIgnored`}
                         />
                     ))}
                 </div>


### PR DESCRIPTION
## Summary
Revived from [#43](https://github.com/Sunny-Tech/SunnyTechWebsite/pull/43), rebased on top of current \`main\`. Adds a view-transition animation so the speaker avatar flies between a session detail page and its speaker profile page (and vice versa).

- \`transition:name\` built from \`session-{sessionId}-speaker-photo-{speakerId}\` so the source and destination avatar elements pair up across pages.
- \`transition:animate="slide"\` for a directional morph.
- A \`viewTransitionPrefix\` prop propagates down to \`SessionItem\` / \`Speaker\` components on the schedule + speaker index pages so the same naming scheme can be reused across contexts (list → detail).
- On the speaker page, related \`SessionItem\` cards use a prefix of \`sessionItemIgnored\` so they aren't part of the animated pair.

## Conflict notes
Re-applied cleanly over \`main\` except for \`src/pages/speakers/[slug].astro\`, which was modified by #64 (per-page social sharing images). The merge preserves both: \`id\` is still destructured for the \`transition:name\`, and \`ogSlug\` + \`metaImage\` stay wired up for the OG card.

## Test plan
- [ ] From \`/schedule/day-1\`, click a session card — speaker avatars in the list animate into the session page speaker block.
- [ ] From a session page, click a speaker — avatar animates to the header of the speaker page.
- [ ] From \`/speakers\`, click a speaker — avatar animates into the speaker page header.
- [ ] Build succeeds (\`npm run build\`): 169 pages generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)