### PR TITLE
Fix duplicated homepage title

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,7 +8,7 @@ import SponsorBanner from '../components/SponsorBanner.astro'
 import { computeOgImageType, computeOgPath } from '../og/ogImage'
 
 interface Props {
-    title: string
+    title?: string
     description?: string
     metaImage?: string | null
 }
@@ -43,7 +43,7 @@ const url = import.meta.env.SITE
 const image = metaImage || url + computeOgPath(Astro.url.pathname)
 const ogImageType = computeOgImageType(image)
 const siteName = 'Sunny Tech'
-const siteNameWithTagline = 'Sunny Tech, la conférence Tech organisée à Montpellier'
+const siteNameWithTagline = 'Sunny Tech 2026, la conférence Tech organisée à Montpellier — 2 & 3 juillet'
 const pageTitle = title || siteName
 const fullPageTitle = title ? `${title} | ${siteName}` : siteNameWithTagline
 const pageDescription =

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ const openPlannerData: OpenPlannerType = await response.json()
 const tickets = openPlannerData.tickets ?? []
 ---
 
-<Layout title="Sunny Tech">
+<Layout>
     <Hero />
 
     <HomeContentBlock />


### PR DESCRIPTION
## Problem

Homepage rendered `<title>Sunny Tech | Sunny Tech</title>` — `index.astro` passed `title="Sunny Tech"` and `Layout` appended `| Sunny Tech`.

## Fix

- Drop the `title` prop on the homepage so it uses the tagline fallback (`title` is now optional in `Layout`)
- Update the tagline to include the year + dates

New title: **Sunny Tech 2026, la conférence Tech organisée à Montpellier — 2 & 3 juillet**

Other pages are unchanged (they still render `X | Sunny Tech`).

## Verify

- `astro check && astro build` passes (170 pages)
- Dev preview `<title>` confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)