### PR TITLE
Honor hideTrackTitle in mobile schedule

### DIFF
--- a/src/components/schedule/ScheduleSessionCell.astro
+++ b/src/components/schedule/ScheduleSessionCell.astro
@@ -31,6 +31,7 @@ const height = session.extendHeight || 1
         track={session.track}
         category={session.category}
         speakers={session.speakers}
+        hideTrackTitle={session.hideTrackTitle}
         language={session.language || 'fr'}
     />
 </div>

--- a/src/components/schedule/SessionItem.astro
+++ b/src/components/schedule/SessionItem.astro
@@ -16,6 +16,7 @@ interface Props {
     speakers: Speaker[]
     alwaysShowExtraInfo?: boolean
     hideBookmark?: boolean
+    hideTrackTitle?: boolean
     language?: string
 }
 
@@ -30,6 +31,7 @@ const {
     language,
     alwaysShowExtraInfo = false,
     hideBookmark = false,
+    hideTrackTitle = false,
 } = Astro.props
 ---
 
@@ -54,7 +56,7 @@ const {
                 } –{' '}
                 {durationMinutes} min
             </div>
-            {track && <div class="schedule-session-track">Salle : {track.name}</div>}
+            {track && !hideTrackTitle && <div class="schedule-session-track">Salle : {track.name}</div>}
         </div>
         <div style={{ marginTop: 'auto', paddingTop: 'var(--s0)' }}>
             <Stack space="var(--s-2)">


### PR DESCRIPTION
## Problem

On mobile, the day schedule renders a `Salle : X` line inside each session card (desktop hides it — the track columns already label the rooms). This line showed even for sessions flagged `hideTrackTitle` (breaks, lunch, cross-track keynotes), where the room is meaningless.

The session **detail** page already respects the flag (`{track && !hideTrackTitle && ...}`), but the schedule `SessionItem` never received it.

## Fix

- Add optional `hideTrackTitle` prop to `SessionItem` and gate the `Salle` line on it
- Pass `session.hideTrackTitle` through `ScheduleSessionCell`

Other `SessionItem` callers (speaker page, cross-day card) are unchanged — default keeps showing the room.

## Verify

- `astro check && astro build` passes (170 pages)
- Day-1 mobile: `Salle` labels drop from 75 → 67, exactly the 8 day-1 `hideTrackTitle` sessions with a track
- Confirmed in mobile preview: badges / keynote / "Pause" cards have no `Salle` line; regular talks still do

🤖 Generated with [Claude Code](https://claude.com/claude-code)